### PR TITLE
Arama Sonuçlarında Tüm Sayfayı Gizleme Hatası

### DIFF
--- a/content.js
+++ b/content.js
@@ -36,7 +36,7 @@
             for (j = 0; j < blockedDomains.length; j++) {
                 if ((results[i].firstChild) && (typeof(results[i].firstChild.hostname) != "undefined") && (results[i].parentNode.parentNode.parentNode)) {
                     if (results[i].firstChild.hostname.includes(blockedDomains[j]) == true) {
-                        results[i].parentNode.parentNode.parentNode.style.display = 'none';
+                        results[i].parentNode.parentNode.style.display = 'none';
                         break;
                     }
                 }


### PR DESCRIPTION
hideResults metodunda 1 katman daha parent node seçildiği için tüm sayfa divini seçiyor bu yüzden de 10 sonucun tamamını gizliyor. 1 katman düşünce seçili sonucu gizlemeyi başarıyla yapıyor.